### PR TITLE
Fix empty <wp:comment> items added in export_wp()

### DIFF
--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -678,7 +678,7 @@ function export_wp( $args = array() ) {
 	endforeach;
 
 				$_comments = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved <> 'spam'", $post->ID ) );
-				$comments  = array_map( 'get_comment', $_comments );
+				$comments  = array_filter( array_map( 'get_comment', $_comments ) );
 				foreach ( $comments as $c ) :
 					?>
 		<wp:comment>


### PR DESCRIPTION
If you wish to exclude comments from the WordPress export you can use the following code:

```
add_action( 'export_wp', function() {
    add_filter( 'get_comment', '__return_false' );
} );
```

However, the export_wp() will still loop through empty values for the $comments array inserting unnecessary <wp:comment> items.

Trac ticket: https://core.trac.wordpress.org/ticket/61244#ticket